### PR TITLE
feat(run): add syncBreakingLabels and support GH Enterprise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 GITHUB_TOKEN=
+# Only needed for enterprise in the format: https://[hostname]/api/v3
+GITHUB_URL=
 MONDAY_KEY=
 MONDAY_BOARD=
 MONDAY_ISSUE_NUMBER_COLUMN_ID=

--- a/run/syncBreakingLabels.ts
+++ b/run/syncBreakingLabels.ts
@@ -17,9 +17,12 @@ async function findAndSyncLabel(label: string): Promise<void> {
 }
 
 async function syncLabel(issue: Issue, label: string): Promise<ActionResponse> {
-  gitRest.dispatchMondayWorkflow(issue, {
-    label_action: "added",
-    label_name: label,
+  gitRest.dispatchMondayWorkflow({
+    issue,
+    inputs: {
+      label_action: "added",
+      label_name: label,
+    },
   });
 
   return "triggered";

--- a/run/syncMilestonedIssues.ts
+++ b/run/syncMilestonedIssues.ts
@@ -1,0 +1,36 @@
+import GitRest from "../src/utils/git-rest";
+import type { ActionResponse, Issue } from "../src/types";
+
+const owner = "Esri";
+const repo = "calcite-design-system";
+
+// Used to sync Devtopia issues
+// const owner = "ArcGISDevelopers";
+// const repo = "calcite-documentation";
+
+const gitRest = GitRest({ owner, repo });
+
+gitRest.iterateAllIssues({
+  action: (issue) => syncMilestone(issue),
+  state: "open",
+  per_page: 50,
+  sleepMs: 60000,
+  milestone: "*",
+});
+
+async function syncMilestone(issue: Issue): Promise<ActionResponse> {
+  if (!issue.milestone) {
+    return "skipped";
+  }
+
+  gitRest.dispatchMondayWorkflow({
+    issue,
+    // Used to sync Devtopia issues
+    // ref: "next",
+    inputs: {
+      milestone_updated: "true",
+    },
+  });
+
+  return "triggered";
+}

--- a/run/unrelatedMergedPrs.ts
+++ b/run/unrelatedMergedPrs.ts
@@ -13,9 +13,7 @@ await gitRest.iterateAllIssues({
   per_page: 100,
 });
 
-async function unrelatedMergedPrs(
-  issue: Issue,
-): Promise<ActionResponse> {
+async function unrelatedMergedPrs(issue: Issue): Promise<ActionResponse> {
   if (
     !issue.pull_request?.merged_at ||
     issue.pull_request?.merged_at <= new Date("2025-09-16").toISOString()
@@ -27,6 +25,9 @@ async function unrelatedMergedPrs(
     return "skipped";
   }
   // No related issue in body
-  gitRest.dispatchMondayWorkflow(issue, { refactor_pr: "true" });
+  gitRest.dispatchMondayWorkflow({
+    issue,
+    inputs: { refactor_pr: "true" },
+  });
   return "triggered";
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,12 @@ export interface RestParams {
   repo: string;
 }
 
+export interface WorkflowDispatchParams {
+  issue: Issue;
+  ref?: string;
+  inputs: WorkflowInputs;
+}
+
 /** Inputs for Monday Sync Workflow */
 export interface WorkflowInputs {
   milestone_updated?: "true" | "false";

--- a/src/utils/git-rest.ts
+++ b/src/utils/git-rest.ts
@@ -10,6 +10,7 @@ import type {
   ActionResponse,
   PaginateParams,
   Milestone,
+  WorkflowDispatchParams,
 } from "../types";
 
 export default function GitRest({ owner, repo }: RestParams) {
@@ -17,6 +18,7 @@ export default function GitRest({ owner, repo }: RestParams) {
     new Promise((resolve) => setTimeout(resolve, ms));
   const octokit = new Octokit({
     auth: process.env.GITHUB_TOKEN,
+    baseUrl: process.env.GITHUB_URL || undefined,
   });
 
   /**
@@ -47,10 +49,11 @@ export default function GitRest({ owner, repo }: RestParams) {
    * Dispatch a GitHub Actions workflow for the given issue
    * @returns ActionResponse indicating the result of the operation
    */
-  async function dispatchMondayWorkflow(
-    issue: Issue,
-    inputs: WorkflowInputs,
-  ): Promise<ActionResponse> {
+  async function dispatchMondayWorkflow({
+    issue,
+    ref = "dev",
+    inputs,
+  }: WorkflowDispatchParams): Promise<ActionResponse> {
     const defaultInputs = {
       issue_number: issue.number.toString(),
       event_type: "SyncActionChanges",
@@ -61,7 +64,7 @@ export default function GitRest({ owner, repo }: RestParams) {
         owner,
         repo,
         workflow_id: "issue-monday-sync.yml",
-        ref: "dev",
+        ref,
         inputs: { ...defaultInputs, ...inputs },
       });
       console.log(`DISPATCHED: ${issue.html_url}`);
@@ -94,7 +97,7 @@ export default function GitRest({ owner, repo }: RestParams) {
       label_action: "added",
     };
 
-    return await dispatchMondayWorkflow(issue, inputs);
+    return await dispatchMondayWorkflow({ issue, inputs });
   }
 
   async function getMilestones(): Promise<Milestone[]> {
@@ -195,7 +198,10 @@ export default function GitRest({ owner, repo }: RestParams) {
   async function syncAssignees(issue: Issue): Promise<ActionResponse> {
     if (issue?.assignees?.length === 0) return "skipped";
 
-    return await dispatchMondayWorkflow(issue, { assignee_updated: "true" });
+    return await dispatchMondayWorkflow({
+      issue,
+      inputs: { assignee_updated: "true" },
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a `syncMilestoneIssues.ts` run script to dispatch a Monday sync Action for any issues that have a milestone.

This needed to be done for the Calcite and enterprise repos, so environment and `git-rest` changes were made to support Enterprise.
